### PR TITLE
Add build/release files cribbed from toit-partition-table-esp32.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,11 @@ jobs:
         run: |
           make
 
+      - name: Tar.gz Linux executable
+        if: runner.os == 'Linux'
+        run: |
+          tar c -zvf build/${{env.APP_NAME}}-linux.tar.gz -C build ${{env.APP_NAME}}
+
       - name: Run tests
         shell: bash
         run: |
@@ -125,12 +130,19 @@ jobs:
           name: binaries-${{ runner.os }}
           path: build/${{env.APP_NAME}}${{ env.BIN_EXTENSION }}
 
+      - name: Upload Linux tar.gz
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries-Linux-tar
+          path: build/${{env.APP_NAME}}-linux.tar.gz
+
       - name: Upload release Linux executable
         if: github.event_name == 'release' && runner.os == 'Linux'
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: build/${{env.APP_NAME}}
+          file: build/${{env.APP_NAME}}-linux.tar.gz
           tag: ${{ github.event.release.tag_name }}
           overwrite: true
 
@@ -164,6 +176,11 @@ jobs:
           mkdir out
           copy build/${{env.APP_NAME}}.exe out/${{env.APP_NAME}}.exe
 
+      - name: Zip signed
+        run: |
+          cd out
+          7z a ${{env.APP_NAME}}-windows.zip ${{env.APP_NAME}}.exe
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -175,7 +192,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: out/${{env.APP_NAME}}.exe
+          file: out/${{env.APP_NAME}}-windows.zip
           tag: ${{ github.event.release.tag_name }}
           overwrite: true
 
@@ -230,12 +247,12 @@ jobs:
           create-dmg \
               --volname "${{env.APP_NAME}}" \
               --add-file ${{env.APP_NAME}} build/${{env.APP_NAME}} 0 0 \
-              out/${{env.APP_NAME}}.dmg \
+              out/${{env.APP_NAME}}-macos.dmg \
               empty
 
       - name: Create a ZIP
         run: |
-          zip -j out/${{env.APP_NAME}}.zip build/${{env.APP_NAME}}
+          zip -j out/${{env.APP_NAME}}-macos.zip build/${{env.APP_NAME}}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -248,7 +265,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: out/${{env.APP_NAME}}.dmg
+          file: out/${{env.APP_NAME}}-macos.dmg
           tag: ${{ github.event.release.tag_name }}
           overwrite: true
 
@@ -257,6 +274,6 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: out/${{env.APP_NAME}}.zip
+          file: out/${{env.APP_NAME}}-macos.zip
           tag: ${{ github.event.release.tag_name }}
           overwrite: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,53 +1,80 @@
+# Copyright (C) 2023 Toitware ApS. All rights reserved.
+
 name: CI
 
 on:
+  workflow_dispatch:
+    inputs:
+      sign_macos:
+        description: Sign the macOS binary
+        type: boolean
+        required: true
+        default: false
+      sign_windows:
+        description: Sign the Windows binary
+        type: boolean
+        required: true
+        default: false
   push:
-  release:
-    types: [published]
+    branches:
+      - "*"
+      - "*/*"
+
+env:
+  TOIT_VERSION: v2.0.0-alpha.114
+  APP_NAME: xxxd
 
 jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup constants
+      - name: Setup Toit
         shell: bash
         run: |
-          TOIT_VERSION=v2.0.0-alpha.97
-          echo "TOIT_VERSION=$TOIT_VERSION" >> $GITHUB_ENV
-          export DOWNLOAD_DIR="${{ github.workspace }}/downloads"
-          echo "DOWNLOAD_DIR=$DOWNLOAD_DIR" >> $GITHUB_ENV
-          if [[ "$RUNNER_OS" = "Linux" ]]; then
-            TOIT_FILE=toit-linux.tar.gz
-            echo "TOIT_EXEC=$DOWNLOAD_DIR/toit/bin/toit.run" >> $GITHUB_ENV
-            echo "TPKG_EXEC=$DOWNLOAD_DIR/toit/bin/toit.pkg" >> $GITHUB_ENV
-            echo "TCOMPILE_EXEC=$DOWNLOAD_DIR/toit/bin/toit.compile" >> $GITHUB_ENV
-          elif [[ "$RUNNER_OS" = "macOS" ]]; then
-            TOIT_FILE=toit-macos.tar.gz
-            echo "TOIT_EXEC=$DOWNLOAD_DIR/toit/bin/toit.run" >> $GITHUB_ENV
-            echo "TPKG_EXEC=$DOWNLOAD_DIR/toit/bin/toit.pkg" >> $GITHUB_ENV
-            echo "TCOMPILE_EXEC=$DOWNLOAD_DIR/toit/bin/toit.compile" >> $GITHUB_ENV
-          elif [[ "$RUNNER_OS" = "Windows" ]]; then
-            TOIT_FILE=toit-windows.tar.gz
-            echo "TOIT_EXEC=$DOWNLOAD_DIR/toit/bin/toit.run.exe" >> $GITHUB_ENV
-            echo "TPKG_EXEC=$DOWNLOAD_DIR/toit/bin/toit.pkg.exe" >> $GITHUB_ENV
-            echo "TCOMPILE_EXEC=$DOWNLOAD_DIR/toit/bin/toit.compile.exe" >> $GITHUB_ENV
-          else
-            echo "UNSUPPORTED RUNNER: $RUNNER_OS"
-            exit 1
+          if [[ "$RUNNER_OS" = "Windows" ]]; then
+            BIN_EXTENSION=".exe"
           fi
+          echo "BIN_EXTENSION=$BIN_EXTENSION" >> $GITHUB_ENV
 
-          if [[ $TOIT_VERSION = latest ]]; then
-            echo "TOIT_URL=https://github.com/toitlang/toit/releases/latest/download/$TOIT_FILE" >> $GITHUB_ENV
-          else
-            echo "TOIT_URL=https://github.com/toitlang/toit/releases/download/$TOIT_VERSION/$TOIT_FILE" >> $GITHUB_ENV
-          fi
+          export NATIVE_DOWNLOAD_DIR="${{ github.workspace }}/downloads"
+          echo "NATIVE_DOWNLOAD_DIR=$NATIVE_DOWNLOAD_DIR" >> $GITHUB_ENV
+
+          export DOWNLOAD_DIR="$PWD/downloads"
+          echo "DOWNLOAD_DIR=$DOWNLOAD_DIR" >> $GITHUB_ENV
+
+          TOIT_SDK_DIR=$DOWNLOAD_DIR/toit
+          echo "TOIT_EXEC=$TOIT_SDK_DIR/bin/toit.run$BIN_EXTENSION" >> $GITHUB_ENV
+          echo "TOITC_EXEC=$TOIT_SDK_DIR/bin/toit.compile$BIN_EXTENSION" >> $GITHUB_ENV
+          echo "TPKG_EXEC=$TOIT_SDK_DIR/bin/toit.pkg$BIN_EXTENSION" >> $GITHUB_ENV
+
+          TOIT_SDK_FILE=toit-$(echo $RUNNER_OS | tr '[:upper:]' '[:lower:]').tar.gz
+          TOIT_SDK_BASE_URL=https://github.com/toitlang/toit/releases
+
+          echo "TOIT_SDK_URL=$TOIT_SDK_BASE_URL/download/$TOIT_VERSION/$TOIT_SDK_FILE" >> $GITHUB_ENV
+
+      - uses: suisei-cn/actions-download-file@v1.3.0
+        name: Download Toit
+        with:
+          url: ${{ env.TOIT_SDK_URL }}
+          target: ${{ env.NATIVE_DOWNLOAD_DIR }}
+
+      - name: Extract Toit
+        shell: bash
+        run: |
+          cd "$DOWNLOAD_DIR"
+          for f in *.tar.gz; do
+            tar x -f $f
+          done
+          ls $TOIT_EXEC
+          ls $TOITC_EXEC
+          ls $TPKG_EXEC
 
       # Fetch the dependencies. Different for each platform.
       - name: Install dependencies - Linux
@@ -70,30 +97,163 @@ jobs:
           ninja --version
           cmake --version
 
-      - uses: suisei-cn/actions-download-file@v1.3.0
-        name: Download Toit
-        with:
-          url: ${{ env.TOIT_URL }}
-          target: ${{ env.DOWNLOAD_DIR }}
-
-      - name: Extract Toit
-        shell: bash
-        run: |
-          cd "$DOWNLOAD_DIR"
-          tar x -f *.tar.gz
-
       - name: Run cmake
         shell: bash
         run: |
           make rebuild-cmake
-          cmake "-DTOIT_EXEC=$TOIT_EXEC" "-DTCOMPILE_EXEC=$TCOMPILE_EXEC" "-DTPKG_EXEC=$TPKG_EXEC" build
+          cmake \
+              -DTOITC="$TOITC_EXEC" \
+              -DTOITPKG="$TPKG_EXEC" \
+              -DTOITRUN="$TOIT_EXEC" \
+              build
 
-      - name: Install packages
+      - name: Build binaries
         shell: bash
         run: |
-          make install-pkgs
+          make
 
-      - name: Test
+      - name: Run tests
         shell: bash
         run: |
           make test
+
+      - name: Upload binary artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries-${{ runner.os }}
+          path: build/${{env.APP_NAME}}${{ env.BIN_EXTENSION }}
+
+      - name: Upload release Linux executable
+        if: github.event_name == 'release' && runner.os == 'Linux'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: build/${{env.APP_NAME}}
+          tag: ${{ github.event.release.tag_name }}
+          overwrite: true
+
+  sign-windows:
+    runs-on: windows-signing || inputs.sign_windows
+    needs: [build]
+    if: github.event_name == 'release'
+    steps:
+      - name: Clean workspace
+        run: |
+          rm -Recurse -Force ${{ github.workspace }}\*
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: binaries-Windows
+          path: in
+
+      - name: Copy to build
+        run: |
+          mkdir build/windows
+          copy in/${{env.APP_NAME}}.exe build/${{env.APP_NAME}}.exe
+
+      - name: Sign ${{env.APP_NAME}}
+        working-directory: ./build
+        # Signs in place.
+        run: |
+          signtool sign /debug /n "Toitware ApS" /t http://timestamp.digicert.com/ $PWD/${{env.APP_NAME}}.exe
+
+      - name: Copy signed to out
+        run: |
+          mkdir out
+          copy build/${{env.APP_NAME}}.exe out/${{env.APP_NAME}}.exe
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries-Windows-signed
+          path: ./out
+
+      - name: Upload release Windows executable
+        if: github.event_name == 'release'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: out/${{env.APP_NAME}}.exe
+          tag: ${{ github.event.release.tag_name }}
+          overwrite: true
+
+  sign_macos:
+    runs-on: macos-latest
+    needs: [build]
+    if: github.event_name == 'release' || inputs.sign_macos
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: binaries-macOS
+          path: in
+
+      - name: Install dependencies
+        run: |
+          set -e
+          brew install create-dmg
+          brew install zip
+
+      - name: Copy to build
+        run: |
+          mkdir -p build
+          cp in/${{env.APP_NAME}} build/${{env.APP_NAME}}
+
+      - name: Setup binary rights
+        run: |
+          chmod +x build/${{env.APP_NAME}}
+
+      - name: Sign and notarize
+        uses: toitlang/action-macos-sign-notarize@v1.0.0
+        with:
+          certificate: ${{ secrets.MACOS_CERTIFICATE }}
+          certificate-password: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          username: ${{ secrets.AC_USERNAME }}
+          password: ${{ secrets.AC_PASSWORD }}
+          apple-team-id: 33DS2ZRDST
+          # Signs in place.
+          app-path: build/${{env.APP_NAME}}
+
+      - name: Create out folder
+        run: |
+          mkdir -p out
+
+      - name: Create a DMG
+        run: |
+          # Use an empty directory as source so we don't accidentally add other files than the
+          # ${{env.APP_NAME}} binary.
+          set -e
+          mkdir empty
+          create-dmg \
+              --volname "${{env.APP_NAME}}" \
+              --add-file ${{env.APP_NAME}} build/${{env.APP_NAME}} 0 0 \
+              out/${{env.APP_NAME}}.dmg \
+              empty
+
+      - name: Create a ZIP
+        run: |
+          zip -j out/${{env.APP_NAME}}.zip build/${{env.APP_NAME}}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries-macOS-signed
+          path: ./out
+
+      - name: Upload release macOS executable DMG
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: out/${{env.APP_NAME}}.dmg
+          tag: ${{ github.event.release.tag_name }}
+          overwrite: true
+
+      - name: Upload release macOS executable ZIP
+        if: github.event_name == 'release'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: out/${{env.APP_NAME}}.zip
+          tag: ${{ github.event.release.tag_name }}
+          overwrite: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,9 +133,9 @@ jobs:
           overwrite: true
 
   sign-windows:
-    runs-on: windows-signing || inputs.sign_windows
+    runs-on: windows-signing
     needs: [build]
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || inputs.sign_windows
     steps:
       - name: Clean workspace
         run: |
@@ -242,6 +242,7 @@ jobs:
           path: ./out
 
       - name: Upload release macOS executable DMG
+        if: github.event_name == 'release'
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ on:
         type: boolean
         required: true
         default: false
+  release:
+    types: [published]
   push:
     branches:
       - "*"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+# Zero-Clause BSD License
+
+# Copyright (C) 2023 Toitware ApS.
+
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted.
+
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+# REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+# INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+# LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+# OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+# PERFORMANCE OF THIS SOFTWARE.
+
+name: Publish package
+on:
+  push:
+    tags:
+    - 'v[0-9]+.[0-9]+.[0-9]+'
+    - 'v[0-9]+.[0-9]+.[0-9]+-*'
+jobs:
+  create-release:
+    name: Create new release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish
+        uses: toitlang/pkg-publish@v1.3.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,11 @@ cmake_minimum_required(VERSION 3.23)
 
 project(xxxd)
 
+set(TOITRUN
+    "toit.run${CMAKE_EXECUTABLE_SUFFIX}"
+    CACHE
+    FILEPATH
+    "The executable used to run programs")
 set(TOITPKG
     "toit.pkg${CMAKE_EXECUTABLE_SUFFIX}"
     CACHE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,21 @@
 # Copyright (C) 2023 Toitware ApS.
-# Use of this source code is governed by a Zero-Clause BSD license that can
-# be found in the tests/TESTS_LICENSE file.
+# Use of this source code is governed by an MIT-style license that can be
+# found in the LICENSE file.
 
 cmake_minimum_required(VERSION 3.23)
 
 project(xxxd)
 
-# Add windows exe extension.
-set(TOIT_EXEC "toit.run${CMAKE_EXECUTABLE_SUFFIX}" CACHE FILEPATH "The executable used to run the tests")
-set(TPKG_EXEC "toit.pkg${CMAKE_EXECUTABLE_SUFFIX}" CACHE FILEPATH "The executable used to install the packages")
-set(TCOMPILE_EXEC "toit.compile${CMAKE_EXECUTABLE_SUFFIX}" CACHE FILEPATH "The executable used to check the syntax")
+set(TOITPKG
+    "toit.pkg${CMAKE_EXECUTABLE_SUFFIX}"
+    CACHE
+    FILEPATH
+    "The executable used to install packages")
+set(TOITC
+    "toit.compile${CMAKE_EXECUTABLE_SUFFIX}"
+    CACHE
+    FILEPATH
+    "The executable used to compile programs and check the syntax")
 
 set(DEFAULT_SDK_VERSION CACHE STRING "The default SDK version to use")
 
@@ -26,6 +32,10 @@ configure_file(
   bin/version.toit.in
   ${CMAKE_CURRENT_SOURCE_DIR}/bin/version.toit
   @ONLY)
+
+include("tools/toit.cmake")
+
+add_custom_target(build)
 
 enable_testing()
 add_subdirectory(bin)

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,31 @@
 # Copyright (C) 2023 Toitware ApS.
-# Use of this source code is governed by a Zero-Clause BSD license that can
-# be found in the tests/TESTS_LICENSE file.
+# Use of this source code is governed by an MIT-style license that can be
+# found in the LICENSE file.
 
-all: test
+.PHONY: all
+all: build
+
+.PHONY: build
+build: rebuild-cmake install-pkgs
+	(cd build && ninja build)
+
+.PHONY: test
+test: rebuild-cmake install-pkgs
+	 (cd build && ninja test)
 
 .PHONY: build/CMakeCache.txt
-
 build/CMakeCache.txt:
 	$(MAKE) rebuild-cmake
 
+.PHONY: install-pkgs
 install-pkgs: rebuild-cmake
-	(cd build && ninja install-pkgs)
-
-test: install-pkgs rebuild-cmake
-	(cd build && ninja check)
+	(cd build && ninja download_packages)
 
 # We rebuild the cmake file all the time.
 # We use "glob" in the cmakefile, and wouldn't otherwise notice if a new
 # file (for example a test) was added or removed.
 # It takes <1s on Linux to run cmake, so it doesn't hurt to run it frequently.
+.PHONY: rebuild-cmake
 rebuild-cmake:
 	mkdir -p build
 	(cd build && cmake .. -G Ninja)
-
-.PHONY: all test rebuild-cmake install-pkgs
-

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build: rebuild-cmake install-pkgs
 
 .PHONY: test
 test: rebuild-cmake install-pkgs
-	 (cd build && ninja test)
+	 (cd build && ninja check)
 
 .PHONY: build/CMakeCache.txt
 build/CMakeCache.txt:

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -1,10 +1,23 @@
 # Copyright (C) 2023 Toitware ApS.
-# Use of this source code is governed by a Zero-Clause BSD license that can
-# be found in the tests/TESTS_LICENSE file.
+# Use of this source code is governed by an MIT-style license that can be
+# found in the LICENSE file.
 
-message("TPKG: ${TPKG_EXEC}")
-add_custom_target(
-  "install-pkgs"
-  COMMAND "${TPKG_EXEC}" install
-  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../bin"
+toit_project(xxxd "${CMAKE_CURRENT_LIST_DIR}")
+
+set(XXXD_SOURCE "${CMAKE_CURRENT_LIST_DIR}/xxxd.toit")
+set(XXXD_EXE "${CMAKE_BINARY_DIR}/xxxd${CMAKE_EXECUTABLE_SUFFIX}")
+set(XXXD_DEP "${CMAKE_CURRENT_BINARY_DIR}/xxxd.dep")
+
+ADD_TOIT_EXE(
+  ${XXXD_SOURCE}
+  ${XXXD_EXE}
+  ${XXXD_DEP}
+  ""
 )
+
+add_custom_target(
+  build_xxxd
+  DEPENDS ${XXXD_EXE}
+)
+
+add_dependencies(build build_xxxd)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,7 +55,7 @@ foreach(file ${TESTS})
 
   add_test(
     NAME "${test_name}"
-    COMMAND "sh" "tests/compare-xxd.sh" ${TOIT_EXEC} "tests/${file}"
+    COMMAND "sh" "tests/compare-xxd.sh" ${TOITRUN} "tests/${file}"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   )
 
@@ -75,7 +75,7 @@ foreach(file ${XXXD_TESTS})
 
   add_test(
     NAME "${test_name}"
-    COMMAND "sh" "tests/xxxd-test.sh" ${TOIT_EXEC} "tests/${file}"
+    COMMAND "sh" "tests/xxxd-test.sh" ${TOITRUN} "tests/${file}"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   )
 

--- a/tools/toit.cmake
+++ b/tools/toit.cmake
@@ -1,0 +1,107 @@
+# Copyright (C) 2023 Toitware ApS.
+# Use of this source code is governed by an MIT-style license that can be
+# found in the LICENSE file.
+
+# This file serves as normal cmake include, as well as a cmake-script, run with
+# `cmake -P`.
+# In the latter case the `EXECUTING_SCRIPT` variable is defined, and we only
+# process the command that we should execute.
+set(TOIT_DOWNLOAD_PACKAGE_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/toit.cmake")
+if (DEFINED EXECUTING_SCRIPT)
+  if ("${SCRIPT_COMMAND}" STREQUAL "install_packages")
+    if (NOT DEFINED TOIT_PROJECT)
+      message(FATAL_ERROR "Missing TOIT_PROJECT")
+    endif()
+    if (NOT DEFINED TOITPKG)
+      message(FATAL_ERROR "Missing TOITPKG")
+    endif()
+
+    if (EXISTS "${TOIT_PROJECT}/package.yaml" OR EXISTS "${TOIT_PROJECT}/package.lock")
+      execute_process(
+        COMMAND "${TOITPKG}" install --auto-sync=false "--project-root=${TOIT_PROJECT}"
+        COMMAND_ERROR_IS_FATAL ANY
+      )
+    endif()
+  else()
+    message(FATAL_ERROR "Unknown script command ${SCRIPT_COMMAND}")
+  endif()
+
+  # End the execution of this file.
+  return()
+endif()
+
+# Creates a custom command to build ${TARGET} with correct dependencies.
+function(ADD_TOIT_SNAPSHOT SOURCE TARGET DEP_FILE ENV)
+  if (NOT DEFINED TOITC)
+    set(TOITC "$ENV{TOITC}")
+    if ("${TOITC}" STREQUAL "")
+      # TOITC is normally set to the toit.compile executable.
+      # However, for cross-compilation the compiler must be provided manually.
+      message(FATAL_ERROR "TOITC not provided")
+    endif()
+  endif()
+  if(POLICY CMP0116)
+    cmake_policy(SET CMP0116 NEW)
+  endif()
+  add_custom_command(
+    OUTPUT "${TARGET}"
+    DEPFILE ${DEP_FILE}
+    DEPENDS download_packages "${SOURCE}"
+    COMMAND ${CMAKE_COMMAND} -E env ${ENV} ASAN_OPTIONS=detect_leaks=false "${TOITC}" --dependency-file "${DEP_FILE}" --dependency-format ninja -w "${TARGET}" "${SOURCE}"
+  )
+endfunction(ADD_TOIT_SNAPSHOT)
+
+# Creates a custom command to build ${TARGET} with correct dependencies.
+function(ADD_TOIT_EXE SOURCE TARGET DEP_FILE ENV)
+  if (NOT DEFINED TOITC)
+    set(TOITC "$ENV{TOITC}")
+    if ("${TOITC}" STREQUAL "")
+      # TOITC is normally set to the toit.compile executable.
+      # However, for cross-compilation the compiler must be provided manually.
+      message(FATAL_ERROR "TOITC not provided")
+    endif()
+  endif()
+  if(POLICY CMP0116)
+    cmake_policy(SET CMP0116 NEW)
+  endif()
+  add_custom_command(
+    OUTPUT "${TARGET}"
+    DEPFILE ${DEP_FILE}
+    DEPENDS download_packages "${SOURCE}"
+    COMMAND ${CMAKE_COMMAND} -E env ${ENV} ASAN_OPTIONS=detect_leaks=false "${TOITC}" --dependency-file "${DEP_FILE}" --dependency-format ninja -o "${TARGET}" "${SOURCE}"
+  )
+endfunction(ADD_TOIT_EXE)
+
+macro(toit_project NAME PATH)
+  if (NOT DEFINED TOITPKG)
+    set(TOITPKG "$ENV{TOITPKG}")
+    if ("${TOITPKG}" STREQUAL "")
+      # TOITPKG is normally set to the toit.pkg executable.
+      # However, for cross-compilation the compiler must be provided manually.
+      message(FATAL_ERROR "TOITPKG not provided")
+    endif()
+  endif()
+
+  if (NOT TARGET download_packages)
+    add_custom_target(
+      download_packages
+    )
+    add_custom_target(
+      sync_packages
+      COMMAND "${TOITPKG}" sync
+    )
+  endif()
+
+  set(DOWNLOAD_TARGET_NAME "download-${NAME}-packages")
+  add_custom_target(
+    "${DOWNLOAD_TARGET_NAME}"
+    COMMAND "${CMAKE_COMMAND}"
+        -DEXECUTING_SCRIPT=true
+        -DSCRIPT_COMMAND=install_packages
+        "-DTOIT_PROJECT=${PATH}"
+        "-DTOITPKG=${TOITPKG}"
+        -P "${TOIT_DOWNLOAD_PACKAGE_SCRIPT}"
+  )
+  add_dependencies(download_packages "${DOWNLOAD_TARGET_NAME}")
+  add_dependencies("${DOWNLOAD_TARGET_NAME}" sync_packages)
+endmacro()


### PR DESCRIPTION
Some files have cosmetic changes to align with
toit-partition-table-esp32 to make it easier to see real differences.